### PR TITLE
Cache-configuration-for-local-runners

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -42,7 +42,7 @@ inputs:
     default: 'false'
     required: false
   cache-dependencies:
-    description: "Enable installed dependency caching. Default: 'false'"
+    description: "Enable installed dependency caching. Default: 'true'"
     default: 'true'
     required: false
   token:


### PR DESCRIPTION
## what

- Caching tools is timing out when trying to cache to github. Toggle this to turn it off.